### PR TITLE
Update

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ class TuyaLan {
                     this.log.warn('Failed to discover %s (%s) in time but will keep looking.', devices[deviceId].name, deviceId);
                 }
             });
-        }, 60000);
+        }, 30000);
     }
 
     registerPlatformAccessories(platformAccessories) {


### PR DESCRIPTION
Homebridge keeps crashing if a device is cut from power outside of homekit. The time to time out should be shortened to minimize the disruption time, perhaps there must be a solution to kill the retry search attempts after 5 seconds. 
This temporary fix may do it.